### PR TITLE
增加chatGLM2+PT的预测代码

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,87 @@
+import os
+
+import torch
+from transformers import AutoConfig, AutoModel, AutoTokenizer
+
+from glm2.modeling_chatglm import ChatGLMForConditionalGeneration
+from glm2.tokenization_chatglm import ChatGLMTokenizer
+import argparse
+
+
+def set_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--device', default='0', type=str, help='')
+
+    parser.add_argument('--max_len', type=int, default=1560, help='')
+    parser.add_argument('--max_src_len', type=int, default=1024, help='')
+    parser.add_argument('--top_p', type=float, default=0.7, help='')
+    parser.add_argument('--do_sample', type=bool, default=False, help='')
+    parser.add_argument('--num_return_sequences', type=int, default=1, help='')
+    parser.add_argument('--model_dir',
+                        default="/home/workspace/from_pretrained/chatglm2-6b", type=str,
+                        help='')
+    parser.add_argument('--ptuning_checkpoint',
+                        default="/home/workspace/code_server/fastllm/ChatGLM-Finetuning/output-glm2-0906/epoch-1-step-45",
+                        type=str,
+                        help='')
+    parser.add_argument('--pre_seq_len', type=int, default=16, help='')
+    parser.add_argument('--prefix_projection', type=bool, default=True, help='')
+
+    return parser.parse_args()
+
+
+def predict_one_sample(model, tokenizer, args, text):
+    max_tgt_len = args.max_len - args.max_src_len - 3
+    with torch.no_grad():
+        text="[Round {}]\n\n问：{}\n\n答：".format(1, text)
+        input_ids = tokenizer.encode(text, max_length=args.max_src_len, truncation=True)
+        input_ids = torch.tensor([input_ids]).to("cuda:{}".format(args.device))
+        generation_kwargs = {
+            "min_length": 5,
+            "max_new_tokens": max_tgt_len,
+            "top_p": args.top_p,
+            "temperature": 0.95,
+            "do_sample": args.do_sample,
+            "num_return_sequences": args.num_return_sequences,
+        }
+        response = model.generate(input_ids, **generation_kwargs)
+
+        res = []
+        for i_r in range(generation_kwargs["num_return_sequences"]):
+            outputs = response.tolist()[i_r][input_ids.shape[1]:]
+            r = tokenizer.decode(outputs).replace("<eop>", "")
+            res.append(r)
+    return res[0]
+
+
+def main():
+    args = set_args()
+
+    tokenizer = ChatGLMTokenizer.from_pretrained(args.ptuning_checkpoint)
+    config = AutoConfig.from_pretrained(args.model_dir, trust_remote_code=True)
+    config.pre_seq_len = args.pre_seq_len
+    config.prefix_projection = args.prefix_projection
+
+    model = AutoModel.from_pretrained(args.model_dir, config=config, trust_remote_code=True)
+    prefix_state_dict = torch.load(os.path.join(args.ptuning_checkpoint, "pytorch_model.bin"))
+    new_prefix_state_dict = {}
+    for k, v in prefix_state_dict.items():
+        if k.startswith("module.transformer.prefix_encoder."):
+            new_prefix_state_dict[k[len("module.transformer.prefix_encoder."):]] = v
+    model.transformer.prefix_encoder.load_state_dict(new_prefix_state_dict)
+    model.transformer.prefix_encoder.float()
+
+    model.half().to("cuda:{}".format(args.device))
+    model.eval()
+
+
+    print('开始进行问答，输入CTRL + C，则退出')
+    while True:
+        print('问：')
+        text = input()
+        pre_res = predict_one_sample(model, tokenizer, args, text)
+        print("答：{}".format(pre_res))
+
+
+if __name__ == '__main__':
+    main()

--- a/predict.py
+++ b/predict.py
@@ -1,0 +1,115 @@
+import torch
+import json
+
+from transformers import AutoConfig, AutoTokenizer, AutoModel
+
+from glm2.modeling_chatglm import ChatGLMForConditionalGeneration
+from glm2.tokenization_chatglm import ChatGLMTokenizer
+from tqdm import tqdm
+import time
+import os
+import argparse
+
+
+def set_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--test_path', default='data/spo_1.json', type=str, help='')
+    parser.add_argument('--device', default='0', type=str, help='')
+    parser.add_argument('--model_dir',
+                        default="/home/workspace/from_pretrained/chatglm2-6b", type=str,
+                        help='')
+    parser.add_argument('--ptuning_checkpoint',
+                        default="/home/workspace/code_server/fastllm/ChatGLM-Finetuning/output-glm2-0906/epoch-1-step-45",
+                        type=str,
+                        help='')
+    parser.add_argument('--max_len', type=int, default=1560, help='')
+    parser.add_argument('--max_src_len', type=int, default=1024, help='')
+    parser.add_argument('--pre_seq_len', type=int, default=16, help='')
+    parser.add_argument('--prefix_projection', type=bool, default=True, help='')
+    parser.add_argument('--prompt_text', type=str,
+                        default=r"你现在是一个信息抽取模型，请你帮我抽取出关系内容为\"性能故障\", \"部件故障\", \"组成\"和 \"检测工具\"的相关三元组，三元组内部用\"_\"连接，三元组之间用\n分割。文本：",
+                        help='')
+    return parser.parse_args()
+
+
+def main():
+    args = set_args()
+
+    tokenizer = ChatGLMTokenizer.from_pretrained(args.ptuning_checkpoint)
+    config = AutoConfig.from_pretrained(args.model_dir, trust_remote_code=True)
+    config.pre_seq_len = args.pre_seq_len
+    config.prefix_projection = args.prefix_projection
+    model = AutoModel.from_pretrained(args.model_dir, config=config, trust_remote_code=True)
+    prefix_state_dict = torch.load(os.path.join(args.ptuning_checkpoint, "pytorch_model.bin"))
+    new_prefix_state_dict = {}
+    for k, v in prefix_state_dict.items():
+        if k.startswith("module.transformer.prefix_encoder."):
+            new_prefix_state_dict[k[len("module.transformer.prefix_encoder."):]] = v
+    model.transformer.prefix_encoder.load_state_dict(new_prefix_state_dict)
+    model.transformer.prefix_encoder.float()
+
+
+    model.half().to("cuda:{}".format(args.device))
+    model.eval()
+
+    save_data = []
+    f1 = 0.0
+    max_tgt_len = args.max_len - args.max_src_len - 3
+    s_time = time.time()
+    with open(args.test_path, "r", encoding="utf-8") as fh:
+        for i, line in enumerate(tqdm(fh, desc="iter")):
+            with torch.no_grad():
+                sample = json.loads(line.strip())
+                src_tokens = tokenizer.tokenize(
+                    "[Round {}]\n\n问：{}\n\n答：".format(1, sample["instruction"] + sample["input"]))
+
+                if len(src_tokens) > args.max_src_len:
+                    # 当输入内容超长时，随向后截断，但保留“\n\n答：”内容
+                    src_tokens = src_tokens[:args.max_src_len - 4] + src_tokens[-4:]
+                # ChatGLM2需要增加[gMASK]、sop两个标记
+                input_ids = [tokenizer.get_command("[gMASK]"),
+                             tokenizer.get_command("sop")] + tokenizer.convert_tokens_to_ids(src_tokens)
+                input_ids = torch.tensor([input_ids]).to("cuda:{}".format(args.device))
+                generation_kwargs = {
+                    "min_length": 5,
+                    "max_new_tokens": max_tgt_len,
+                    "top_p": 0.7,
+                    "temperature": 0.95,
+                    "do_sample": False,
+                    "num_return_sequences": 1,
+                }
+                response = model.generate(input_ids, **generation_kwargs)
+                res = []
+                for i_r in range(generation_kwargs["num_return_sequences"]):
+                    outputs = response.tolist()[i_r][input_ids.shape[1]:]
+                    r = tokenizer.decode(outputs).replace("<eop>", "")
+                    res.append(r)
+
+                pre_res = [rr for rr in res[0].split("\n") if len(rr.split("_")) == 3]
+                real_res = sample["output"].split("\n")
+                same_res = set(pre_res) & set(real_res)
+                if len(set(pre_res)) == 0:
+                    p = 0.0
+                else:
+                    p = len(same_res) / len(set(pre_res))
+                r = len(same_res) / len(set(real_res))
+                if (p + r) != 0.0:
+                    f = 2 * p * r / (p + r)
+                else:
+                    f = 0.0
+                f1 += f
+                print(f)
+                save_data.append(
+                    {"text": sample["input"], "ori_answer": sample["output"], "gen_answer": res[0], "f1": f})
+
+    e_time = time.time()
+    print("总耗时：{}s".format(e_time - s_time))
+    print(f1 / 50)
+
+    fin = open("data/ft_pt_answer.json", "w", encoding="utf-8")
+    json.dump(save_data, fin, ensure_ascii=False, indent=4)
+    fin.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,19 @@
+CUDA_VISIBLE_DEVICES=0 deepspeed --master_port 520 train.py \
+                --train_path data/spo_0.json \
+                --model_name_or_path /home/workspace/from_pretrained/chatglm2-6b \
+                --per_device_train_batch_size 8 \
+                --max_len 1560 \
+                --max_src_len 1024 \
+                --learning_rate 1e-4 \
+                --weight_decay 0.1 \
+                --num_train_epochs 10 \
+                --gradient_accumulation_steps 4 \
+                --warmup_ratio 0.1 \
+                --mode glm2 \
+                --train_type ptuning \
+                --seed 1234 \
+                --ds_file ds_zero2_no_offload.json \
+                --show_loss_step 10 \
+                --pre_seq_len 16 \
+                --prefix_projection True \
+                --output_dir ./output-glm2


### PR DESCRIPTION
Description

1. 修改了模型保存方式，只保存PrefixEncoder部分
2. 优化了训练过程的日志打印方式
3. 新增了预测和cli代码

在chatGLM2+PT场景下，可以复现三元组抽取任务, 不同epoch的模型f1在测试集上表现为：

- Epoch 1 0.4001908179539758
- Epoch 5  0.48332597625972235
- Epoch 7  0.5810401474342651
- Epoch 10 0.5901889823940757

基本和作者的实验相符